### PR TITLE
Update required for import inside wysiwyg.vue file affected by the change of the library name geeks-solutions to geeks.solutions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.0.23
+#### Bug Fix
+
+- Fix a wrong import from @geeks-solutions/vue-sections to @geeks.solutions/vue-sections for wysiwyg.vue file
+
 ### 1.0.22
 #### Bug Fixes + Improvements
 
@@ -6,6 +11,7 @@
 - Adjust the popup when clicking on configurable section not authorised yet
 - Update library name from @geeks-solutions/vue-sections to @geeks.solutions/vue-sections
 
+### 1.0.21
 #### Bug Fixes
 
 - Fixed copy anchor problem

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@geeks-solutions/vue-sections",
-  "version": "1.0.20",
+  "name": "@geeks.solutions/vue-sections",
+  "version": "1.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@geeks.solutions/vue-sections",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4610,7 +4610,7 @@
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
       "dev": true
     },
     "debug": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geeks.solutions/vue-sections",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "author": "Geeks Solutions info@geeks.solutions (https://www.geeks.solutions)",
   "repository": {
     "type": "git",

--- a/src/base/index.vue
+++ b/src/base/index.vue
@@ -149,7 +149,7 @@
               <BackIcon />
             </div>
 
-            <div v-if="!currentSection" class="m-1 p-1 type-items">
+            <div v-if="!currentSection" class="m-1 p-1 type-items content-wrapper">
               <div
                   class="section-item section-item-box bg-blue"
                   v-for="(type, index) in types"
@@ -1905,5 +1905,15 @@ span.handle {
 }
 .justify-between {
   justify-content: space-between;
+}
+.content-wrapper {
+  overflow-y: scroll;
+  height: 550px;
+}
+@media only screen and (max-height: 800px) {
+  .content-wrapper {
+    overflow-y: scroll;
+    height: 450px;
+  }
 }
 </style>

--- a/src/configs/forms/wysiwyg.vue
+++ b/src/configs/forms/wysiwyg.vue
@@ -9,7 +9,7 @@ import "quill/dist/quill.snow.css";
 import "quill/dist/quill.bubble.css";
 
 import { quillEditor } from "vue-quill-editor";
-import {globalFileUpload} from "@geeks-solutions/vue-sections";
+import {globalFileUpload} from "@geeks.solutions/vue-sections";
 
 export default {
   components: {


### PR DESCRIPTION
Update required for import inside wysiwyg.vue file affected by the change of the library name geeks-solutions to geeks.solutions.

The problem was not showing because of conflicting package name with old geeks-solutions one. When deleting package-lock.json and reinstalling the new package, the problem appear